### PR TITLE
Fix build issue : TerminalApp.h missing

### DIFF
--- a/src/cascadia/TerminalApp/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalApp.vcxproj
@@ -104,6 +104,9 @@
       <Private>true</Private>
       <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
     </ProjectReference>
+    <ProjectReference Include="..\TerminalSettings\TerminalSettings.vcxproj">
+      <Project>{ca5cad1a-d7ec-4107-b7c6-79cb77ae2907}</Project>
+    </ProjectReference>
 
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Compile/Build issue:
[Build Error] Cannot open include file: 'winrt/TerminalApp.h': No such file or directory

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Related to #659 and #489, #565

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
